### PR TITLE
global-#35: Initial implementation data usage in CLI

### DIFF
--- a/base/base.go
+++ b/base/base.go
@@ -8,6 +8,7 @@ import (
 	"github.com/raito-io/cli/common/api"
 	"github.com/raito-io/cli/common/api/data_access"
 	"github.com/raito-io/cli/common/api/data_source"
+	"github.com/raito-io/cli/common/api/data_usage"
 	"github.com/raito-io/cli/common/api/identity_store"
 	"sync"
 )
@@ -35,24 +36,31 @@ func buildPluginMap(pluginImpls ...interface{}) (plugin.PluginSet, error) {
 	for _, plugin := range pluginImpls {
 		if iss, ok := plugin.(identity_store.IdentityStoreSyncer); ok {
 			if _, f := pluginMap[identity_store.IdentityStoreSyncerName]; f {
-				return nil, errors.New("multiple implementation for IdentityStoreSyncer Plugin found. There should be only one")
+				return nil, errors.New("multiple implementations for IdentityStoreSyncer Plugin found. There should be only one")
 			}
 			pluginMap[identity_store.IdentityStoreSyncerName] = &identity_store.IdentityStoreSyncerPlugin{Impl: iss}
 			logger.Debug("Registered IdentityStoreSyncer Plugin")
 		}
 		if dss, ok := plugin.(data_source.DataSourceSyncer); ok {
 			if _, f := pluginMap[data_source.DataSourceSyncerName]; f {
-				return nil, errors.New("multiple implementation for DataSourceSyncer Plugin found. There should be only one")
+				return nil, errors.New("multiple implementations for DataSourceSyncer Plugin found. There should be only one")
 			}
 			pluginMap[data_source.DataSourceSyncerName] = &data_source.DataSourceSyncerPlugin{Impl: dss}
 			logger.Debug("Registered DataSourceSyncer Plugin")
 		}
 		if das, ok := plugin.(data_access.DataAccessSyncer); ok {
 			if _, f := pluginMap[data_access.DataAccessSyncerName]; f {
-				return nil, errors.New("multiple implementation for DataAccessSyncer Plugin found. There should be only one")
+				return nil, errors.New("multiple implementations for DataAccessSyncer Plugin found. There should be only one")
 			}
 			pluginMap[data_access.DataAccessSyncerName] = &data_access.DataAccessSyncerPlugin{Impl: das}
 			logger.Debug("Registered DataAccessSyncer Plugin")
+		}
+		if dus, ok := plugin.(data_usage.DataUsageSyncer); ok {
+			if _, f := pluginMap[data_usage.DataUsageSyncerName]; f {
+				return nil, errors.New("multiple implementations for DataUsageSyncer Plugin found. There should be only one")
+			}
+			pluginMap[data_usage.DataUsageSyncerName] = &data_usage.DataUsageSyncerPlugin{Impl: dus}
+			logger.Debug("Registered DataUsageSyncer Plugin")
 		}
 		if i, ok := plugin.(api.Info); ok {
 			if _, f := pluginMap[api.InfoName]; f {
@@ -80,7 +88,7 @@ func buildPluginMap(pluginImpls ...interface{}) (plugin.PluginSet, error) {
 func RegisterPlugins(pluginImpls ...interface{}) error {
 	Logger()
 
-	pluginMap, err := buildPluginMap(pluginImpls...);
+	pluginMap, err := buildPluginMap(pluginImpls...)
 	if err != nil {
 		return err
 	}

--- a/base/data_usage/data_usage_test.go
+++ b/base/data_usage/data_usage_test.go
@@ -77,7 +77,7 @@ func TestDataUsageFileCreator(t *testing.T) {
 		RowsReturned:     0,
 	})
 
-	err = dufc.AddStatement(dus)
+	err = dufc.AddStatements(dus)
 	assert.Nil(t, err)
 	dufc.Close()
 

--- a/base/data_usage/data_usage_test.go
+++ b/base/data_usage/data_usage_test.go
@@ -26,10 +26,10 @@ func TestDataUsageFileCreator(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, dufc)
 
-	dus := make([]TransactionStatement, 0, 3)
-	dus = append(dus, TransactionStatement{
+	dus := make([]Statement, 0, 3)
+	dus = append(dus, Statement{
 		ExternalId:       "transaction1",
-		Resource:         "schema1.table1.column1",
+		Resources:        []string{"schema1.table1.column1"},
 		Action:           "SELECT",
 		Status:           true,
 		User:             "Alice",
@@ -39,9 +39,10 @@ func TestDataUsageFileCreator(t *testing.T) {
 		BytesTransferred: 52,
 		RowsReturned:     3,
 	})
-	dus = append(dus, TransactionStatement{
-		ExternalId:       "transaction2",
-		Resource:         "schema1.table2.column3",
+	dus = append(dus, Statement{
+		ExternalId: "transaction2",
+		Resources: []string{"schema1.table2.column3",
+			"schema1.table2.column5", "schema1.table2.column7"},
 		Action:           "ALTER",
 		Status:           false,
 		User:             "Alice",
@@ -51,9 +52,9 @@ func TestDataUsageFileCreator(t *testing.T) {
 		BytesTransferred: 180,
 		RowsReturned:     27,
 	})
-	dus = append(dus, TransactionStatement{
+	dus = append(dus, Statement{
 		ExternalId:       "transaction3",
-		Resource:         "schema3",
+		Resources:        []string{"schema3"},
 		Action:           "GRANT",
 		Status:           true,
 		User:             "Bob",
@@ -64,23 +65,23 @@ func TestDataUsageFileCreator(t *testing.T) {
 		RowsReturned:     0,
 	})
 
-	err = dufc.AddTransaction(dus)
+	err = dufc.AddStatement(dus)
 	assert.Nil(t, err)
 	dufc.Close()
 
-	assert.Equal(t, 3, dufc.GetTransactionCount())
+	assert.Equal(t, 3, dufc.GetStatementCount())
 
 	bytes, err := ioutil.ReadAll(tempFile)
 	assert.Nil(t, err)
 
-	dusr := make([]TransactionStatement, 0, 3)
+	dusr := make([]Statement, 0, 3)
 	err = json.Unmarshal(bytes, &dusr)
 	assert.Nil(t, err)
 
 	assert.Equal(t, 3, len(dusr))
 
 	assert.Equal(t, "transaction1", dusr[0].ExternalId)
-	assert.Equal(t, "schema1.table1.column1", dusr[0].Resource)
+	assert.Equal(t, []string{"schema1.table1.column1"}, dusr[0].Resources)
 	assert.Equal(t, "SELECT", dusr[0].Action)
 	assert.Equal(t, true, dusr[0].Status)
 	assert.Equal(t, "Alice", dusr[0].User)
@@ -91,7 +92,8 @@ func TestDataUsageFileCreator(t *testing.T) {
 	assert.Equal(t, 3, dusr[0].RowsReturned)
 
 	assert.Equal(t, "transaction2", dusr[1].ExternalId)
-	assert.Equal(t, "schema1.table2.column3", dusr[1].Resource)
+	assert.Equal(t, []string{"schema1.table2.column3",
+		"schema1.table2.column5", "schema1.table2.column7"}, dusr[1].Resources)
 	assert.Equal(t, "ALTER", dusr[1].Action)
 	assert.Equal(t, false, dusr[1].Status)
 	assert.Equal(t, "Alice", dusr[1].User)
@@ -102,7 +104,7 @@ func TestDataUsageFileCreator(t *testing.T) {
 	assert.Equal(t, 27, dusr[1].RowsReturned)
 
 	assert.Equal(t, "transaction3", dusr[2].ExternalId)
-	assert.Equal(t, "schema3", dusr[2].Resource)
+	assert.Equal(t, []string{"schema3"}, dusr[2].Resources)
 	assert.Equal(t, "GRANT", dusr[2].Action)
 	assert.Equal(t, true, dusr[2].Status)
 	assert.Equal(t, "Bob", dusr[2].User)

--- a/base/data_usage/data_usage_test.go
+++ b/base/data_usage/data_usage_test.go
@@ -1,0 +1,114 @@
+package data_usage
+
+import (
+	"encoding/json"
+	"github.com/raito-io/cli/common/api/data_usage"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func TestDataUsageFileCreator(t *testing.T) {
+	tempFile, _ := os.Create("tempfile-" + strconv.Itoa(rand.Int()) + ".json")
+	defer os.Remove(tempFile.Name())
+	config := data_usage.DataUsageSyncConfig{
+		TargetFile: tempFile.Name(),
+	}
+	dufc, err := NewDataUsageFileCreator(&config)
+	assert.Nil(t, err)
+	assert.NotNil(t, dufc)
+
+	dus := make([]TransactionStatement, 0, 3)
+	dus = append(dus, TransactionStatement{
+		ExternalId:       "transaction1",
+		Resource:         "schema1.table1.column1",
+		Action:           "SELECT",
+		Status:           true,
+		User:             "Alice",
+		StartTime:        1654073198000,
+		EndTime:          1654073198050,
+		TotalTime:        0.05,
+		BytesTransferred: 52,
+		RowsReturned:     3,
+	})
+	dus = append(dus, TransactionStatement{
+		ExternalId:       "transaction2",
+		Resource:         "schema1.table2.column3",
+		Action:           "ALTER",
+		Status:           false,
+		User:             "Alice",
+		StartTime:        1654073199000,
+		EndTime:          1654073199060,
+		TotalTime:        0.06,
+		BytesTransferred: 180,
+		RowsReturned:     27,
+	})
+	dus = append(dus, TransactionStatement{
+		ExternalId:       "transaction3",
+		Resource:         "schema3",
+		Action:           "GRANT",
+		Status:           true,
+		User:             "Bob",
+		StartTime:        1654073200000,
+		EndTime:          1654073200020,
+		TotalTime:        0.02,
+		BytesTransferred: 0,
+		RowsReturned:     0,
+	})
+
+	err = dufc.AddTransaction(dus)
+	assert.Nil(t, err)
+	dufc.Close()
+
+	assert.Equal(t, 3, dufc.GetTransactionCount())
+
+	bytes, err := ioutil.ReadAll(tempFile)
+	assert.Nil(t, err)
+
+	dusr := make([]TransactionStatement, 0, 3)
+	err = json.Unmarshal(bytes, &dusr)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 3, len(dusr))
+
+	assert.Equal(t, "transaction1", dusr[0].ExternalId)
+	assert.Equal(t, "schema1.table1.column1", dusr[0].Resource)
+	assert.Equal(t, "SELECT", dusr[0].Action)
+	assert.Equal(t, true, dusr[0].Status)
+	assert.Equal(t, "Alice", dusr[0].User)
+	assert.Equal(t, int64(1654073198000), dusr[0].StartTime)
+	assert.Equal(t, int64(1654073198050), dusr[0].EndTime)
+	assert.Equal(t, float32(0.05), dusr[0].TotalTime)
+	assert.Equal(t, 52, dusr[0].BytesTransferred)
+	assert.Equal(t, 3, dusr[0].RowsReturned)
+
+	assert.Equal(t, "transaction2", dusr[1].ExternalId)
+	assert.Equal(t, "schema1.table2.column3", dusr[1].Resource)
+	assert.Equal(t, "ALTER", dusr[1].Action)
+	assert.Equal(t, false, dusr[1].Status)
+	assert.Equal(t, "Alice", dusr[1].User)
+	assert.Equal(t, int64(1654073199000), dusr[1].StartTime)
+	assert.Equal(t, int64(1654073199060), dusr[1].EndTime)
+	assert.Equal(t, float32(0.06), dusr[1].TotalTime)
+	assert.Equal(t, 180, dusr[1].BytesTransferred)
+	assert.Equal(t, 27, dusr[1].RowsReturned)
+
+	assert.Equal(t, "transaction3", dusr[2].ExternalId)
+	assert.Equal(t, "schema3", dusr[2].Resource)
+	assert.Equal(t, "GRANT", dusr[2].Action)
+	assert.Equal(t, true, dusr[2].Status)
+	assert.Equal(t, "Bob", dusr[2].User)
+	assert.Equal(t, int64(1654073200000), dusr[2].StartTime)
+	assert.Equal(t, int64(1654073200020), dusr[2].EndTime)
+	assert.Equal(t, float32(0.02), dusr[2].TotalTime)
+	assert.Equal(t, 0, dusr[2].BytesTransferred)
+	assert.Equal(t, 0, dusr[2].RowsReturned)
+}

--- a/base/data_usage/importer.go
+++ b/base/data_usage/importer.go
@@ -1,0 +1,108 @@
+package data_usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/raito-io/cli/common/api/data_usage"
+	"os"
+)
+
+type TransactionStatement struct {
+	ExternalId       string  `json:"externalId"`
+	Resource         string  `json:"resource"`
+	Action           string  `json:"action"`
+	Status           bool    `json:"status"`
+	User             string  `json:"user"`
+	StartTime        int64   `json:"startTime"`
+	EndTime          int64   `json:"endTime"`
+	TotalTime        float32 `json:"totalTime"`
+	BytesTransferred int     `json:"bytesTransferred"`
+	RowsReturned     int     `json:"rowsReturned"`
+}
+
+// DataUsageFileCreator describes the interface for easily creating the data usage import files
+// to be exported from the Raito CLI.
+type DataUsageFileCreator interface {
+	AddTransaction(Statement []TransactionStatement) error
+	Close()
+	GetTransactionCount() int
+}
+
+type dataUsageFileCreator struct {
+	config     *data_usage.DataUsageSyncConfig
+	targetFile *os.File
+	queryCount int
+}
+
+func NewDataUsageFileCreator(config *data_usage.DataUsageSyncConfig) (DataUsageFileCreator, error) {
+	duI := dataUsageFileCreator{
+		config: config,
+	}
+
+	err := duI.createTargetFile()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = duI.targetFile.Write([]byte("["))
+	if err != nil {
+		return nil, err
+	}
+
+	return &duI, nil
+}
+
+// AddTransaction adds the slice of data objects to the import file.
+// It returns an error when writing one of the data objects fails (it will not process the other data objects after that).
+// It returns nil if everything went well.
+func (d *dataUsageFileCreator) AddTransaction(queries []TransactionStatement) error {
+	if len(queries) == 0 {
+		return nil
+	}
+
+	for _, do := range queries {
+		var err error
+
+		if d.queryCount > 0 {
+			d.targetFile.Write([]byte(",")) //nolint:errcheck
+		}
+		d.targetFile.Write([]byte("\n")) //nolint:errcheck
+
+		doBuf, err := json.Marshal(do)
+		if err != nil {
+			return fmt.Errorf("error while serializing data object with externalID %q", do.ExternalId)
+		}
+		//d.targetFile.Write([]byte("\n")) //nolint:errcheck
+		_, err = d.targetFile.Write(doBuf)
+
+		// Only looking at writing errors at the end, supposing if one fails, all would fail
+		if err != nil {
+			return fmt.Errorf("error while writing to temp file %q", d.targetFile.Name())
+		}
+		d.queryCount++
+	}
+
+	return nil
+}
+
+// Close finalizes the import file and close it so it can be correctly read by the Raito CLI.
+// This method must be called when all data objects have been added and before control is given back
+// to the CLI. It's advised to call this using 'defer'.
+func (d *dataUsageFileCreator) Close() {
+	d.targetFile.Write([]byte("\n]")) //nolint:errcheck
+	d.targetFile.Close()
+}
+
+// GetTransactionCount returns the number of data objects that has been added to the import file.
+func (d *dataUsageFileCreator) GetTransactionCount() int {
+	return d.queryCount
+}
+
+func (d *dataUsageFileCreator) createTargetFile() error {
+	f, err := os.Create(d.config.TargetFile)
+	if err != nil {
+		return fmt.Errorf("error creating temporary file for data usage importer: %s", err.Error())
+	}
+	d.targetFile = f
+	return nil
+}

--- a/base/data_usage/importer.go
+++ b/base/data_usage/importer.go
@@ -3,21 +3,21 @@ package data_usage
 import (
 	"encoding/json"
 	"fmt"
+	ap "github.com/raito-io/cli/base/access_provider"
 	"github.com/raito-io/cli/common/api/data_usage"
 	"os"
 )
 
 type Statement struct {
-	ExternalId       string   `json:"externalId"`
-	Resources        []string `json:"resources"`
-	Action           string   `json:"action"`
-	Status           bool     `json:"status"`
-	User             string   `json:"user"`
-	StartTime        int64    `json:"startTime"`
-	EndTime          int64    `json:"endTime"`
-	TotalTime        float32  `json:"totalTime"`
-	BytesTransferred int      `json:"bytesTransferred"`
-	RowsReturned     int      `json:"rowsReturned"`
+	ExternalId          string      `json:"externalId"`
+	AccessedDataObjects []ap.Access `json:"accessedDataObjects"`
+	Status              bool        `json:"status"`
+	User                string      `json:"user"`
+	StartTime           int64       `json:"startTime"`
+	EndTime             int64       `json:"endTime"`
+	TotalTime           float32     `json:"totalTime"`
+	BytesTransferred    int         `json:"bytesTransferred"`
+	RowsReturned        int         `json:"rowsReturned"`
 }
 
 // DataUsageFileCreator describes the interface for easily creating the data usage import files

--- a/base/data_usage/importer.go
+++ b/base/data_usage/importer.go
@@ -23,7 +23,7 @@ type Statement struct {
 // DataUsageFileCreator describes the interface for easily creating the data usage import files
 // to be exported from the Raito CLI.
 type DataUsageFileCreator interface {
-	AddStatement(Statement []Statement) error
+	AddStatements(statements []Statement) error
 	Close()
 	GetStatementCount() int
 }
@@ -55,7 +55,7 @@ func NewDataUsageFileCreator(config *data_usage.DataUsageSyncConfig) (DataUsageF
 // AddTransaction adds the slice of data objects to the import file.
 // It returns an error when writing one of the data objects fails (it will not process the other data objects after that).
 // It returns nil if everything went well.
-func (d *dataUsageFileCreator) AddStatement(statements []Statement) error {
+func (d *dataUsageFileCreator) AddStatements(statements []Statement) error {
 	if len(statements) == 0 {
 		return nil
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -357,7 +357,7 @@ func syncDataUsage(client *plugin.PluginClient, targetConfig target.BaseTargetCo
 	if err != nil {
 		return err
 	}
-	targetConfig.Logger.Info(fmt.Sprintf("Successfully synced data usage. Added: %d transactions", duResult.TransactionAdded))
+	targetConfig.Logger.Info(fmt.Sprintf("Successfully synced data usage. Added: %d transactions", duResult.StatementsAdded))
 
 	return nil
 }

--- a/common/api/data_usage/data_usage.go
+++ b/common/api/data_usage/data_usage.go
@@ -1,0 +1,66 @@
+package data_usage
+
+import (
+	"github.com/hashicorp/go-plugin"
+	"github.com/raito-io/cli/common/api"
+	"github.com/raito-io/cli/common/util/config"
+	"net/rpc"
+)
+
+// DataUsageSyncConfig represents the configuration that is passed from the CLI to the DataUsageSyncer plugin interface.
+// It contains all the necessary configuration parameters for the plugin to function.
+type DataUsageSyncConfig struct {
+	config.ConfigMap
+	TargetFile string
+}
+
+// DataUsageSyncResult represents the result from the data usage sync process.
+// A potential error is also modeled in here so specific errors remain intact when passed over RPC.
+type DataUsageSyncResult struct {
+	Error *api.ErrorResult
+}
+
+// DataUsageSyncer interface needs to be implemented by any plugin that wants to import data usage information
+// into a Raito data source.
+type DataUsageSyncer interface {
+	SyncDataUsage(config *DataUsageSyncConfig) DataUsageSyncResult
+}
+
+// DataUsageSyncerPlugin is used on the server (CLI) and client (plugin) side to integrate with the plugin system.
+// A plugin should not be using this directly, but instead depend on the cli-plugin-base library to register the plugins.
+type DataUsageSyncerPlugin struct {
+	Impl DataUsageSyncer
+}
+
+func (p *DataUsageSyncerPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+	return &dataUsageSyncerRPCServer{Impl: p.Impl}, nil
+}
+
+func (DataUsageSyncerPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+	return &dataUsageSyncerRPC{client: c}, nil
+}
+
+// DataUsageSyncerName constant should not be used directly when implementing plugins.
+// It's the registration name for the data usage syncer plugin,
+// used by the CLI and the cli-plugin-base library (RegisterPlugins function) to register the plugins.
+const DataUsageSyncerName = "dataUsageSyncer"
+
+type dataUsageSyncerRPC struct{ client *rpc.Client }
+
+func (g *dataUsageSyncerRPC) SyncDataUsage(config *DataUsageSyncConfig) DataUsageSyncResult {
+	var resp DataUsageSyncResult
+	err := g.client.Call("Plugin.SyncDataUsage", config, &resp)
+	if err != nil && resp.Error == nil {
+		resp.Error = api.ToErrorResult(err)
+	}
+	return resp
+}
+
+type dataUsageSyncerRPCServer struct {
+	Impl DataUsageSyncer
+}
+
+func (s *dataUsageSyncerRPCServer) SyncDataUsage(config *DataUsageSyncConfig, resp *DataUsageSyncResult) error {
+	*resp = s.Impl.SyncDataUsage(config)
+	return nil
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -14,6 +14,7 @@ var KnownFlags = map[string]struct{}{
 	SkipIdentityStoreSyncFlag: struct{}{},
 	SkipDataSourceSyncFlag:    struct{}{},
 	SkipDataAccessSyncFlag:    struct{}{},
+	SkipDataUsageSyncFlag:     struct{}{},
 	DataSourceIdFlag:          struct{}{},
 	IdentityStoreIdFlag:       struct{}{},
 	OnlyTargetsFlag:           struct{}{},
@@ -40,6 +41,7 @@ const (
 	SkipDataSourceSyncFlag    = "skip-data-source-sync"
 	SkipDataAccessSyncFlag    = "skip-data-access-sync"
 	SkipIdentityStoreSyncFlag = "skip-identity-store-sync"
+	SkipDataUsageSyncFlag     = "skip-data-usage-sync"
 	DataSourceIdFlag          = "data-source-id"
 	IdentityStoreIdFlag       = "identity-store-id"
 	OnlyTargetsFlag           = "only-targets"

--- a/internal/data_usage/importer.go
+++ b/internal/data_usage/importer.go
@@ -1,0 +1,69 @@
+package data_usage
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-hclog"
+	"github.com/raito-io/cli/internal/constants"
+	"github.com/raito-io/cli/internal/file"
+	"github.com/raito-io/cli/internal/graphql"
+	"github.com/raito-io/cli/internal/target"
+	"github.com/spf13/viper"
+	"time"
+)
+
+type DataUsageImportConfig struct {
+	target.BaseTargetConfig
+	TargetFile string
+}
+
+type DataUsageImportResult struct {
+	TransactionAdded int             `json:"transactionsAdded"`
+	Errors           []graphql.Error `json:"_"`
+}
+
+type DataUsageImporter interface {
+	TriggerImport() (*DataUsageImportResult, error)
+}
+
+type dataUsageImporter struct {
+	config *DataUsageImportConfig
+	log    hclog.Logger
+}
+
+func NewDataUsageImporter(config *DataUsageImportConfig) DataUsageImporter {
+	logger := config.Logger.With("data-usage", config.DataSourceId, "file", config.TargetFile)
+	duI := dataUsageImporter{config, logger}
+	return &duI
+}
+
+func (d *dataUsageImporter) TriggerImport() (*DataUsageImportResult, error) {
+	env := viper.GetString(constants.EnvironmentFlag)
+	if env == constants.EnvironmentDev {
+		// In the development environment, we skip the upload and use the local file for the import
+		return d.doImport(d.config.TargetFile)
+	} else {
+		key, err := d.upload()
+		if err != nil {
+			return nil, err
+		}
+
+		return d.doImport(key)
+	}
+}
+
+func (d *dataUsageImporter) upload() (string, error) {
+	key, err := file.UploadFile(d.config.TargetFile, &d.config.BaseTargetConfig)
+	if err != nil {
+		return "", fmt.Errorf("error while uploading data usage import files to Raito: %s", err.Error())
+	}
+	return key, nil
+}
+
+func (d *dataUsageImporter) doImport(fileKey string) (*DataUsageImportResult, error) {
+	start := time.Now()
+
+	d.log.Info(fmt.Sprintf("Actual import to appserver still needs to be implemented, reading from file %s", fileKey))
+	d.log.Info(fmt.Sprintf("Done executing import in %s", time.Since(start).Round(time.Millisecond)))
+
+	return &DataUsageImportResult{}, nil
+}

--- a/internal/data_usage/importer.go
+++ b/internal/data_usage/importer.go
@@ -17,8 +17,8 @@ type DataUsageImportConfig struct {
 }
 
 type DataUsageImportResult struct {
-	TransactionAdded int             `json:"transactionsAdded"`
-	Errors           []graphql.Error `json:"_"`
+	StatementsAdded int             `json:"statementsAdded"`
+	Errors          []graphql.Error `json:"_"`
 }
 
 type DataUsageImporter interface {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -30,7 +30,7 @@ const LATEST = "latest"
 var nameRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9]$`)
 var versionRegexp = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
 
-var localPluginFolder = "~/.raito/plugins/"
+var localPluginFolder = "./raito/plugins/"
 var globalPluginFolder string
 
 var pluginMap = map[string]plugin.Plugin{

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/raito-io/cli/common/api"
 	"github.com/raito-io/cli/common/api/data_access"
 	"github.com/raito-io/cli/common/api/data_source"
+	"github.com/raito-io/cli/common/api/data_usage"
 	"github.com/raito-io/cli/common/api/identity_store"
 	"io"
 	"io/fs"
@@ -25,17 +26,19 @@ import (
 // TODO add cancel and async (done context) support
 
 const LATEST = "latest"
+
 var nameRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9]$`)
 var versionRegexp = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
 
-var localPluginFolder = "./raito/plugins/"
+var localPluginFolder = "~/.raito/plugins/"
 var globalPluginFolder string
 
 var pluginMap = map[string]plugin.Plugin{
 	"identityStoreSyncer": &identity_store.IdentityStoreSyncerPlugin{},
-	"dataSourceSyncer": &data_source.DataSourceSyncerPlugin{},
-	"dataAccessSyncer": &data_access.DataAccessSyncerPlugin{},
-	"info": &api.InfoPlugin{},
+	"dataSourceSyncer":    &data_source.DataSourceSyncerPlugin{},
+	"dataAccessSyncer":    &data_access.DataAccessSyncerPlugin{},
+	"dataUsageSyncer":     &data_usage.DataUsageSyncerPlugin{},
+	"info":                &api.InfoPlugin{},
 }
 
 func init() {
@@ -57,6 +60,7 @@ type PluginClient interface {
 	GetDataSourceSyncer() (data_source.DataSourceSyncer, error)
 	GetIdentityStoreSyncer() (identity_store.IdentityStoreSyncer, error)
 	GetDataAccessSyncer() (data_access.DataAccessSyncer, error)
+	GetDataUsageSyncer() (data_usage.DataUsageSyncer, error)
 	GetInfo() (api.Info, error)
 }
 
@@ -82,14 +86,14 @@ func NewPluginClient(connector string, version string, logger hclog.Logger) (Plu
 		return nil, fmt.Errorf("error connecting to plugin %q. It may be corrupt or invalid", connector)
 	}
 
-	pci := pluginClientImpl{client }
+	pci := pluginClientImpl{client}
 
 	is, err := pci.GetInfo()
 	if err != nil {
 		return nil, fmt.Errorf("the plugin (%s) doesn't correctly implement the necessary interfaces", connector)
 	}
 	info := is.PluginInfo()
-	logger.Debug("Using plugin: "+info.String())
+	logger.Debug("Using plugin: " + info.String())
 
 	return pci, nil
 }
@@ -166,7 +170,7 @@ func extractFromDownloadFile(pluginRequest *pluginRequest, downloadedFile, targe
 }
 
 func extractTarGz(gzipStream io.Reader, extractedPath string) (string, error) {
-	parentFolder := extractedPath[0:strings.LastIndex(extractedPath, "/")+1]
+	parentFolder := extractedPath[0 : strings.LastIndex(extractedPath, "/")+1]
 	err := os.MkdirAll(parentFolder, fs.ModePerm)
 	if err != nil {
 		return "", fmt.Errorf("error while creating plugin parent folder %q: %s", parentFolder, err.Error())
@@ -247,7 +251,7 @@ func getLatestVersion(matches []string) string {
 	return versions[len(versions)-1].String()
 }
 
-func parsePluginRequest (connector string, version string) (*pluginRequest, error) {
+func parsePluginRequest(connector string, version string) (*pluginRequest, error) {
 	if strings.Count(connector, "/") != 1 {
 		return nil, errors.New("the connector name is expected to have exactly 1 slash (/) in it")
 	}
@@ -284,8 +288,8 @@ func parsePluginRequest (connector string, version string) (*pluginRequest, erro
 	}
 
 	return &pluginRequest{
-		Name: name,
-		Group: group,
+		Name:    name,
+		Group:   group,
 		Version: version,
 	}, nil
 }
@@ -302,7 +306,7 @@ func (c pluginClientImpl) Close() {
 	c.client.Kill()
 }
 
-// TODO once Go Generics are released, these 3 methodes can probably be implemented in 1 helper
+// TODO once Go Generics are released, these 4 methodes can probably be implemented in 1 helper
 
 func (c pluginClientImpl) GetDataSourceSyncer() (data_source.DataSourceSyncer, error) {
 	rpcClient, err := c.client.Client()
@@ -358,6 +362,24 @@ func (c pluginClientImpl) GetDataAccessSyncer() (data_access.DataAccessSyncer, e
 	}
 }
 
+func (c pluginClientImpl) GetDataUsageSyncer() (data_usage.DataUsageSyncer, error) {
+	rpcClient, err := c.client.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := rpcClient.Dispense(data_usage.DataUsageSyncerName)
+	if err != nil {
+		return nil, err
+	}
+
+	if syncer, ok := raw.(data_usage.DataUsageSyncer); ok {
+		return syncer, nil
+	} else {
+		return nil, fmt.Errorf("found plugin doesn't correctly implement the DataUsageSyncer interface")
+	}
+}
+
 func (c pluginClientImpl) GetInfo() (api.Info, error) {
 	rpcClient, err := c.client.Client()
 	if err != nil {
@@ -383,8 +405,8 @@ var handshakeConfig = plugin.HandshakeConfig{
 }
 
 type pluginRequest struct {
-	Group string
-	Name string
+	Group   string
+	Name    string
 	Version string
 }
 

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -26,6 +26,7 @@ type BaseTargetConfig struct {
 	SkipIdentityStoreSync bool
 	SkipDataSourceSync    bool
 	SkipDataAccessSync    bool
+	SkipDataUsageSync     bool
 	Logger                hclog.Logger
 
 	DeleteUntouched bool
@@ -127,6 +128,7 @@ func buildTargetConfigFromMap(baseLogger hclog.Logger, target map[interface{}]in
 	tConfig.SkipDataAccessSync = tConfig.SkipDataAccessSync || viper.GetBool(constants.SkipDataAccessSyncFlag)
 	tConfig.SkipDataSourceSync = tConfig.SkipDataSourceSync || viper.GetBool(constants.SkipDataSourceSyncFlag)
 	tConfig.SkipIdentityStoreSync = tConfig.SkipIdentityStoreSync || viper.GetBool(constants.SkipIdentityStoreSyncFlag)
+	tConfig.SkipDataUsageSync = tConfig.SkipDataUsageSync || viper.GetBool(constants.SkipDataUsageSyncFlag)
 
 	// Merge with import parameters
 	tConfig.DeleteUntouched = tConfig.DeleteUntouched || viper.GetBool(constants.DeleteUntouchedFlag)
@@ -203,6 +205,7 @@ func buildTargetConfigFromFlags(baseLogger hclog.Logger, otherArgs []string) (*B
 		SkipIdentityStoreSync: viper.GetBool(constants.SkipIdentityStoreSyncFlag),
 		SkipDataSourceSync:    viper.GetBool(constants.SkipDataSourceSyncFlag),
 		SkipDataAccessSync:    viper.GetBool(constants.SkipDataAccessSyncFlag),
+		SkipDataUsageSync:     viper.GetBool(constants.SkipDataUsageSyncFlag),
 		Logger:                baseLogger.With("target", name),
 		DeleteUntouched:       viper.GetBool(constants.DeleteUntouchedFlag),
 		DeleteTempFiles:       viper.GetBool(constants.DeleteTempFilesFlag),


### PR DESCRIPTION
Initial implementation data usage in CLI. Developed in parallel with the Snowflake plugin (without any SQL parsing yet). No actual import is done to the appserver yet; it ends at generated a file to import. 

Not sure at all about the data model for the usage data, but at least there's a version that we can iterate on. Notion page: https://www.notion.so/raitoio/Data-Usage-logs-61c510403bed4a51a3711d99225de5bb 