### PR TITLE
global-53. Trigger data usage processing in appserver after import

### DIFF
--- a/base/data_usage/importer.go
+++ b/base/data_usage/importer.go
@@ -3,9 +3,10 @@ package data_usage
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+
 	ap "github.com/raito-io/cli/base/access_provider"
 	"github.com/raito-io/cli/common/api/data_usage"
-	"os"
 )
 
 type Statement struct {
@@ -36,7 +37,8 @@ type dataUsageFileCreator struct {
 
 func NewDataUsageFileCreator(config *data_usage.DataUsageSyncConfig) (DataUsageFileCreator, error) {
 	duI := dataUsageFileCreator{
-		config: config,
+		config:         config,
+		statementCount: 0,
 	}
 
 	err := duI.createTargetFile()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -385,7 +385,8 @@ func syncDataUsage(client *plugin.PluginClient, targetConfig target.BaseTargetCo
 	if err != nil {
 		return err
 	}
-	targetConfig.Logger.Info(fmt.Sprintf("Successfully synced data usage. Added: %d transactions", duResult.StatementsAdded))
+	targetConfig.Logger.Info(fmt.Sprintf("Successfully synced data usage. %d statements added, %d failed",
+		duResult.StatementsAdded, duResult.StatementsFailed))
 
 	return nil
 }


### PR DESCRIPTION
The remaining piece of the puzzle on the CLI side. The import can now be triggered on the appserver, which will make it easier for testing and development on the appserver side. 