### PR TITLE
28 handle import errors better

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,9 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gookit/color v1.4.2 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.15.3
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.15.3
 	github.com/hashicorp/go-hclog v1.1.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/jinzhu/copier v0.3.4
@@ -36,7 +37,6 @@ require (
 	github.com/gookit/color v1.4.2 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,7 @@ github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQ
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -248,6 +249,8 @@ github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.4.3 h1:DXmvivbWD5qdiBts9TpBC7BYL1Aia5sxbRgQB+v6UZM=
 github.com/hashicorp/go-plugin v1.4.3/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=

--- a/internal/access_provider/importer.go
+++ b/internal/access_provider/importer.go
@@ -85,6 +85,7 @@ func (d *accessProviderImporter) doImport(fileKey string) (*AccessProviderImport
 
 	res := Response{}
 	_, err := graphql.ExecuteGraphQL(gqlQuery, &d.config.BaseTargetConfig, &res)
+
 	if err != nil {
 		return nil, fmt.Errorf("error while executing import: %s", err.Error())
 	}

--- a/internal/access_provider/importer.go
+++ b/internal/access_provider/importer.go
@@ -1,7 +1,6 @@
 package access_provider
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -21,10 +20,9 @@ type AccessProviderImportConfig struct {
 }
 
 type AccessProviderImportResult struct {
-	AccessAdded   int             `json:"accessAdded"`
-	AccessUpdated int             `json:"accessUpdated"`
-	AccessRemoved int             `json:"accessRemoved"`
-	Errors        []graphql.Error `json:"_"`
+	AccessAdded   int `json:"accessAdded"`
+	AccessUpdated int `json:"accessUpdated"`
+	AccessRemoved int `json:"accessRemoved"`
 }
 
 type AccessProviderImporter interface {
@@ -85,38 +83,17 @@ func (d *accessProviderImporter) doImport(fileKey string) (*AccessProviderImport
 
 	gqlQuery = strings.Replace(gqlQuery, "\n", "\\n", -1)
 
-	res, err := graphql.ExecuteGraphQL(gqlQuery, &d.config.BaseTargetConfig)
+	res := Response{}
+	_, err := graphql.ExecuteGraphQL(gqlQuery, &d.config.BaseTargetConfig, &res)
 	if err != nil {
 		return nil, fmt.Errorf("error while executing import: %s", err.Error())
 	}
 
-	ret, err := d.parseImportResult(res)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(ret.Errors) > 0 {
-		return ret, fmt.Errorf("errors while importing into data source: %s", ret.Errors[0].Message)
-	}
+	ret := &res.ImportAccessProviders
 
 	d.log.Info(fmt.Sprintf("Done executing import in %s", time.Since(start).Round(time.Millisecond)))
 
 	return ret, nil
-}
-
-func (d *accessProviderImporter) parseImportResult(res []byte) (*AccessProviderImportResult, error) {
-	resp := Response{}
-	gr := graphql.GraphqlResponse{Data: &resp}
-	err := json.Unmarshal(res, &gr)
-
-	if err != nil {
-		return nil, fmt.Errorf("error while parsing data source import result: %s", err.Error())
-	}
-
-	// Flatten the result
-	resp.ImportAccessProviders.Errors = gr.Errors
-
-	return &(resp.ImportAccessProviders), nil
 }
 
 type Response struct {

--- a/internal/data_source/importer.go
+++ b/internal/data_source/importer.go
@@ -87,6 +87,7 @@ func (d *dataSourceImporter) doImport(fileKey string) (*DataSourceImportResult, 
 
 	res := Response{}
 	_, err := graphql.ExecuteGraphQL(gqlQuery, &d.config.BaseTargetConfig, &res)
+
 	if err != nil {
 		return nil, fmt.Errorf("error while executing import: %s", err.Error())
 	}

--- a/internal/data_source/metadata.go
+++ b/internal/data_source/metadata.go
@@ -36,7 +36,7 @@ func SetMetaData(config target.BaseTargetConfig, metadata data_source.MetaData) 
 
 	gqlQuery = strings.Replace(gqlQuery, "\n", "\\n", -1)
 
-	_, err = graphql.ExecuteGraphQL(gqlQuery, &config)
+	err = graphql.ExecuteGraphQLWithoutResponse(gqlQuery, &config)
 	if err != nil {
 		return fmt.Errorf("error while executing import: %s", err.Error())
 	}

--- a/internal/data_usage/importer.go
+++ b/internal/data_usage/importer.go
@@ -80,6 +80,7 @@ func (d *dataUsageImporter) doImport(fileKey string) (*DataUsageImportResult, er
 
 	res := Response{}
 	_, err := graphql.ExecuteGraphQL(gqlQuery, &d.config.BaseTargetConfig, &res)
+
 	if err != nil {
 		return nil, fmt.Errorf("error while executing data usage import on appserver: %s", err.Error())
 	}

--- a/internal/graphql/graphql.go
+++ b/internal/graphql/graphql.go
@@ -24,6 +24,7 @@ type dummyResultObject struct{}
 func ExecuteGraphQLWithoutResponse(gql string, config *target.BaseTargetConfig) error {
 	result := dummyResultObject{}
 	_, err := ExecuteGraphQL(gql, config, result)
+
 	return err
 }
 
@@ -35,6 +36,7 @@ func ExecuteGraphQL(gql string, config *target.BaseTargetConfig, resultObject in
 	}
 
 	response := GraphqlResponse{Data: resultObject}
+
 	err = json.Unmarshal(rawResponse, &response)
 	if err != nil {
 		return nil, err
@@ -45,11 +47,11 @@ func ExecuteGraphQL(gql string, config *target.BaseTargetConfig, resultObject in
 		for _, error := range response.Errors {
 			errors = append(errors, fmt.Errorf("graphql server error: %s", error.Message))
 		}
+
 		return &response, multierror.Append(nil, errors...)
 	}
 
 	return &response, nil
-
 }
 
 func executeGraphQL(gql string, config *target.BaseTargetConfig) ([]byte, error) {

--- a/internal/graphql/graphql.go
+++ b/internal/graphql/graphql.go
@@ -19,11 +19,8 @@ type Error struct {
 	Message string `json:"message"`
 }
 
-type dummyResultObject struct{}
-
 func ExecuteGraphQLWithoutResponse(gql string, config *target.BaseTargetConfig) error {
-	result := dummyResultObject{}
-	_, err := ExecuteGraphQL(gql, config, result)
+	_, err := ExecuteGraphQL(gql, config, struct{}{})
 
 	return err
 }

--- a/internal/graphql/graphql_test.go
+++ b/internal/graphql/graphql_test.go
@@ -1,15 +1,23 @@
 package graphql
 
 import (
-	"github.com/hashicorp/go-hclog"
-	"github.com/raito-io/cli/internal/target"
-	url2 "github.com/raito-io/cli/internal/util/url"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
+	"github.com/raito-io/cli/internal/target"
+	url2 "github.com/raito-io/cli/internal/util/url"
+	"github.com/stretchr/testify/assert"
 )
+
+type dataObject struct {
+	Name   string  `json:"name"`
+	Height float64 `json:"height"`
+	Mass   int     `json:"mass"`
+}
 
 func TestGraphQL(t *testing.T) {
 	var body, contentType, token, url, method string
@@ -23,7 +31,16 @@ func TestGraphQL(t *testing.T) {
 
 		url = req.RequestURI
 		res.WriteHeader(200)
-		res.Write([]byte("body"))
+		res.Write([]byte(`
+		{
+			"data": {
+				"name": "Luke Skywalker",
+				"height": 1.72,
+				"mass": 77
+			},
+			"errors": []
+		}
+		`))
 	}))
 	defer testServer.Close()
 
@@ -36,16 +53,21 @@ func TestGraphQL(t *testing.T) {
 		Logger:    hclog.Default(),
 	}
 
-	buf, err := ExecuteGraphQL("{ \"operationName\": \"nastyOperation\" }", &config)
+	data := dataObject{}
+	gqlResponse, err := ExecuteGraphQL("{ \"operationName\": \"nastyOperation\" }", &config, &data)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, buf)
+	assert.NotNil(t, gqlResponse)
 	assert.Equal(t, "{ \"operationName\": \"nastyOperation\" }", body)
 	assert.Equal(t, "application/json", contentType)
 	assert.Equal(t, "token idToken", token)
 	assert.Equal(t, "/query", url)
 	assert.Equal(t, "POST", method)
-	assert.Equal(t, "body", string(buf))
+	assert.Equal(t, "Luke Skywalker", data.Name)
+	assert.Equal(t, 1.72, data.Height)
+	assert.Equal(t, 77, data.Mass)
+	assert.Empty(t, gqlResponse.Errors)
+	assert.Equal(t, &data, gqlResponse.Data)
 }
 
 func TestGraphQLError(t *testing.T) {
@@ -61,10 +83,11 @@ func TestGraphQLError(t *testing.T) {
 		Logger: hclog.Default(),
 	}
 
-	buf, err := ExecuteGraphQL("{ \"operationName\": \"nastyOperation\" }", &config)
+	data := dataObject{}
+	gqlResponse, err := ExecuteGraphQL("{ \"operationName\": \"nastyOperation\" }", &config, &data)
 
 	assert.NotNil(t, err)
-	assert.Nil(t, buf)
+	assert.Nil(t, gqlResponse)
 }
 
 func TestGraphQLIllegalURL(t *testing.T) {
@@ -74,8 +97,204 @@ func TestGraphQLIllegalURL(t *testing.T) {
 		Logger: hclog.Default(),
 	}
 
-	buf, err := ExecuteGraphQL("{ \"operationName\": \"nastyOperation\" }", &config)
+	data := dataObject{}
+	gqlReponse, err := ExecuteGraphQL("{ \"operationName\": \"nastyOperation\" }", &config, &data)
 
 	assert.NotNil(t, err)
-	assert.Nil(t, buf)
+	assert.Nil(t, gqlReponse)
+}
+
+func TestGraphQLServerError(t *testing.T) {
+	var body, contentType, token, url, method string
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		buf, _ := ioutil.ReadAll(req.Body)
+		body = string(buf)
+		contentType = req.Header.Get("Content-Type")
+		token = req.Header.Get("Authorization")
+		method = req.Method
+
+		url = req.RequestURI
+		res.WriteHeader(200)
+		res.Write([]byte(`
+		{
+			"data": {
+				"name": "Luke Skywalker",
+				"height": 1.72,
+				"mass": 77
+			},
+			"errors": [
+				{
+					"message": "Boom! This is an error message"
+				},
+				{
+					"message": "A second error"
+				}
+			]
+		}
+		`))
+	}))
+	defer testServer.Close()
+
+	url2.TestURL = testServer.URL
+
+	config := target.BaseTargetConfig{
+		Domain:    "TestRaito",
+		ApiUser:   "Userke",
+		ApiSecret: "SecretStuff",
+		Logger:    hclog.Default(),
+	}
+
+	data := dataObject{}
+	gqlResponse, err := ExecuteGraphQL("{ \"operationName\": \"nastyOperation\" }", &config, &data)
+
+	assert.NotNil(t, err)
+	assert.NotNil(t, gqlResponse)
+	assert.Equal(t, "{ \"operationName\": \"nastyOperation\" }", body)
+	assert.Equal(t, "application/json", contentType)
+	assert.Equal(t, "token idToken", token)
+	assert.Equal(t, "/query", url)
+	assert.Equal(t, "POST", method)
+	assert.Equal(t, "Luke Skywalker", data.Name)
+	assert.Equal(t, 1.72, data.Height)
+	assert.Equal(t, 77, data.Mass)
+	assert.Len(t, gqlResponse.Errors, 2)
+	assert.Equal(t, &data, gqlResponse.Data)
+
+	if merr, ok := err.(*multierror.Error); ok {
+		assert.Len(t, merr.Errors, 2)
+	} else {
+		assert.Fail(t, "Expecting mutlierror")
+	}
+}
+
+func TestGraphQLWithoutResponse(t *testing.T) {
+	var body, contentType, token, url, method string
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		buf, _ := ioutil.ReadAll(req.Body)
+		body = string(buf)
+		contentType = req.Header.Get("Content-Type")
+		token = req.Header.Get("Authorization")
+		method = req.Method
+
+		url = req.RequestURI
+		res.WriteHeader(200)
+		res.Write([]byte(`
+		{
+			"data": {
+				"name": "Luke Skywalker",
+				"height": 1.72,
+				"mass": 77
+			},
+			"errors": []
+		}
+		`))
+	}))
+	defer testServer.Close()
+
+	url2.TestURL = testServer.URL
+
+	config := target.BaseTargetConfig{
+		Domain:    "TestRaito",
+		ApiUser:   "Userke",
+		ApiSecret: "SecretStuff",
+		Logger:    hclog.Default(),
+	}
+
+	err := ExecuteGraphQLWithoutResponse("{ \"operationName\": \"nastyOperation\" }", &config)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "{ \"operationName\": \"nastyOperation\" }", body)
+	assert.Equal(t, "application/json", contentType)
+	assert.Equal(t, "token idToken", token)
+	assert.Equal(t, "/query", url)
+	assert.Equal(t, "POST", method)
+}
+
+func TestGraphQLErrorWithoutResponse(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(500)
+		res.Write([]byte("bad stuff"))
+	}))
+	defer testServer.Close()
+
+	url2.TestURL = testServer.URL
+
+	config := target.BaseTargetConfig{
+		Logger: hclog.Default(),
+	}
+
+	err := ExecuteGraphQLWithoutResponse("{ \"operationName\": \"nastyOperation\" }", &config)
+
+	assert.NotNil(t, err)
+}
+
+func TestGraphQLIllegalURLWithoutReponse(t *testing.T) {
+	url2.TestURL = "//\nbadbadbad"
+
+	config := target.BaseTargetConfig{
+		Logger: hclog.Default(),
+	}
+
+	err := ExecuteGraphQLWithoutResponse("{ \"operationName\": \"nastyOperation\" }", &config)
+
+	assert.NotNil(t, err)
+}
+
+func TestGraphQLServerErrorWithoutResponse(t *testing.T) {
+	var body, contentType, token, url, method string
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		buf, _ := ioutil.ReadAll(req.Body)
+		body = string(buf)
+		contentType = req.Header.Get("Content-Type")
+		token = req.Header.Get("Authorization")
+		method = req.Method
+
+		url = req.RequestURI
+		res.WriteHeader(200)
+		res.Write([]byte(`
+		{
+			"data": {
+				"name": "Luke Skywalker",
+				"height": 1.72,
+				"mass": 77
+			},
+			"errors": [
+				{
+					"message": "Boom! This is an error message"
+				},
+				{
+					"message": "A second error"
+				}
+			]
+		}
+		`))
+	}))
+	defer testServer.Close()
+
+	url2.TestURL = testServer.URL
+
+	config := target.BaseTargetConfig{
+		Domain:    "TestRaito",
+		ApiUser:   "Userke",
+		ApiSecret: "SecretStuff",
+		Logger:    hclog.Default(),
+	}
+
+	err := ExecuteGraphQLWithoutResponse("{ \"operationName\": \"nastyOperation\" }", &config)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "{ \"operationName\": \"nastyOperation\" }", body)
+	assert.Equal(t, "application/json", contentType)
+	assert.Equal(t, "token idToken", token)
+	assert.Equal(t, "/query", url)
+	assert.Equal(t, "POST", method)
+
+	if merr, ok := err.(*multierror.Error); ok {
+		assert.Len(t, merr.Errors, 2)
+	} else {
+		assert.Fail(t, "Expecting mutlierror")
+	}
 }

--- a/internal/identity_store/importer.go
+++ b/internal/identity_store/importer.go
@@ -102,6 +102,7 @@ func (i *identityStoreImporter) doImport(userKey string, groupKey string) (*Iden
 
 	res := Response{}
 	_, err := graphql.ExecuteGraphQL(gqlQuery, &i.config.BaseTargetConfig, &res)
+
 	if err != nil {
 		return nil, fmt.Errorf("error while executing identity store import: %s", err.Error())
 	}

--- a/internal/identity_store/importer_test.go
+++ b/internal/identity_store/importer_test.go
@@ -1,16 +1,17 @@
 package identity_store
 
 import (
-	"github.com/hashicorp/go-hclog"
-	"github.com/raito-io/cli/internal/target"
-	"github.com/raito-io/cli/internal/util/url"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/raito-io/cli/internal/target"
+	"github.com/raito-io/cli/internal/util/url"
+	"github.com/stretchr/testify/assert"
 )
 
 const GoodImportResult = "{ \"data\": { \"importIdentityStore\": { \"usersAdded\": 1, \"usersUpdated\": 2, \"usersRemoved\": 3, \"groupsAdded\": 4, \"groupsUpdated\": 5, \"groupsRemoved\": 6 } } }"
@@ -160,7 +161,7 @@ func TestIdentityStoreImportWithErrors(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "twisted")
-	assert.NotNil(t, res)
+	assert.Nil(t, res)
 }
 
 func UploadServer(fail bool, didUpload *bool, correctContent *bool) *httptest.Server {

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -19,6 +19,7 @@ func StartJob(cfg *target.BaseTargetConfig) (string, error) {
 
 		resp := Response{}
 		_, err := graphql.ExecuteGraphQL(gqlQuery, cfg, &resp)
+
 		if err != nil {
 			return "", fmt.Errorf("error while executing import: %s", err.Error())
 		}

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -1,7 +1,6 @@
 package job
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -18,17 +17,10 @@ func StartJob(cfg *target.BaseTargetConfig) (string, error) {
 
 		gqlQuery = strings.ReplaceAll(gqlQuery, "\n", "\\n")
 
-		res, err := graphql.ExecuteGraphQL(gqlQuery, cfg)
+		resp := Response{}
+		_, err := graphql.ExecuteGraphQL(gqlQuery, cfg, &resp)
 		if err != nil {
 			return "", fmt.Errorf("error while executing import: %s", err.Error())
-		}
-
-		resp := Response{}
-		gr := graphql.GraphqlResponse{Data: &resp}
-
-		err = json.Unmarshal(res, &gr)
-		if err != nil {
-			return "", fmt.Errorf("error while parsing job event result: %s", err.Error())
 		}
 
 		return *resp.Job.JobID, nil
@@ -45,7 +37,7 @@ func AddJobEvent(cfg *target.BaseTargetConfig, jobID, jobType, status string) {
 
 		gqlQuery = strings.ReplaceAll(gqlQuery, "\n", "\\n")
 
-		_, err := graphql.ExecuteGraphQL(gqlQuery, cfg)
+		err := graphql.ExecuteGraphQLWithoutResponse(gqlQuery, cfg)
 		if err != nil {
 			cfg.Logger.Debug("job update failed: %s", err.Error())
 		}


### PR DESCRIPTION
To make sure we always catch all service side GQL errors (that are part of the body of the message). I refactored the graphQL layer a bit. We will always decode the message and check on errors. If there are (one or more) errors. These errors will be forwarded. 
Additionally, you can just provide a body object to the ExecuteGraphQL call. In this way there is no need to parse the message in different places in the code. 