### PR TITLE
Feature/global 54 67 69 79 97 115 smaller issues

### DIFF
--- a/base/data_usage/data_usage_test.go
+++ b/base/data_usage/data_usage_test.go
@@ -2,16 +2,17 @@ package data_usage
 
 import (
 	"encoding/json"
-	"github.com/raito-io/cli/base/access_provider"
-	"github.com/raito-io/cli/base/data_source"
-	"github.com/raito-io/cli/common/api/data_usage"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/raito-io/cli/base/access_provider"
+	"github.com/raito-io/cli/base/data_source"
+	"github.com/raito-io/cli/common/api/data_usage"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -36,13 +37,14 @@ func TestDataUsageFileCreator(t *testing.T) {
 			{DataObjectReference: &data_source.DataObjectReference{"schema1.table1.column1", "column"},
 				Permissions: []string{"SELECT"}},
 		},
-		Status:           true,
-		User:             "Alice",
-		StartTime:        1654073198000,
-		EndTime:          1654073198050,
-		TotalTime:        0.05,
-		BytesTransferred: 52,
-		RowsReturned:     3,
+		Success:   true,
+		Status:    "",
+		User:      "Alice",
+		StartTime: 1654073198000,
+		EndTime:   1654073198050,
+		Bytes:     52,
+		Rows:      3,
+		Credits:   0,
 	})
 	dus = append(dus, Statement{
 		ExternalId: "transaction2",
@@ -54,13 +56,13 @@ func TestDataUsageFileCreator(t *testing.T) {
 			{DataObjectReference: &data_source.DataObjectReference{"schema1.table2.column7", "column"},
 				Permissions: []string{"ALTER"}},
 		},
-		Status:           false,
-		User:             "Alice",
-		StartTime:        1654073199000,
-		EndTime:          1654073199060,
-		TotalTime:        0.06,
-		BytesTransferred: 180,
-		RowsReturned:     27,
+		Success:   false,
+		Status:    "",
+		User:      "Alice",
+		StartTime: 1654073199000,
+		EndTime:   1654073199060,
+		Bytes:     180,
+		Rows:      27,
 	})
 	dus = append(dus, Statement{
 		ExternalId: "transaction3",
@@ -68,13 +70,14 @@ func TestDataUsageFileCreator(t *testing.T) {
 			{DataObjectReference: &data_source.DataObjectReference{"schema3", "schema"},
 				Permissions: []string{"GRANT"}},
 		},
-		Status:           true,
-		User:             "Bob",
-		StartTime:        1654073200000,
-		EndTime:          1654073200020,
-		TotalTime:        0.02,
-		BytesTransferred: 0,
-		RowsReturned:     0,
+		Success:   true,
+		Status:    "",
+		User:      "Bob",
+		StartTime: 1654073200000,
+		EndTime:   1654073200020,
+		Bytes:     0,
+		Rows:      0,
+		Credits:   0,
 	})
 
 	err = dufc.AddStatements(dus)
@@ -95,13 +98,12 @@ func TestDataUsageFileCreator(t *testing.T) {
 	assert.Equal(t, "transaction1", dusr[0].ExternalId)
 	assert.Equal(t, []string{"SELECT"}, dusr[0].AccessedDataObjects[0].Permissions)
 	assert.Equal(t, &data_source.DataObjectReference{FullName: "schema1.table1.column1", Type: "column"}, dusr[0].AccessedDataObjects[0].DataObjectReference)
-	assert.Equal(t, true, dusr[0].Status)
+	assert.Equal(t, true, dusr[0].Success)
 	assert.Equal(t, "Alice", dusr[0].User)
 	assert.Equal(t, int64(1654073198000), dusr[0].StartTime)
 	assert.Equal(t, int64(1654073198050), dusr[0].EndTime)
-	assert.Equal(t, float32(0.05), dusr[0].TotalTime)
-	assert.Equal(t, 52, dusr[0].BytesTransferred)
-	assert.Equal(t, 3, dusr[0].RowsReturned)
+	assert.Equal(t, 52, dusr[0].Bytes)
+	assert.Equal(t, 3, dusr[0].Rows)
 
 	assert.Equal(t, "transaction2", dusr[1].ExternalId)
 	assert.Equal(t, []string{"ALTER"}, dusr[1].AccessedDataObjects[0].Permissions)
@@ -110,22 +112,20 @@ func TestDataUsageFileCreator(t *testing.T) {
 	assert.Equal(t, &data_source.DataObjectReference{FullName: "schema1.table2.column3", Type: "column"}, dusr[1].AccessedDataObjects[0].DataObjectReference)
 	assert.Equal(t, &data_source.DataObjectReference{FullName: "schema1.table2.column5", Type: "column"}, dusr[1].AccessedDataObjects[1].DataObjectReference)
 	assert.Equal(t, &data_source.DataObjectReference{FullName: "schema1.table2.column7", Type: "column"}, dusr[1].AccessedDataObjects[2].DataObjectReference)
-	assert.Equal(t, false, dusr[1].Status)
+	assert.Equal(t, false, dusr[1].Success)
 	assert.Equal(t, "Alice", dusr[1].User)
 	assert.Equal(t, int64(1654073199000), dusr[1].StartTime)
 	assert.Equal(t, int64(1654073199060), dusr[1].EndTime)
-	assert.Equal(t, float32(0.06), dusr[1].TotalTime)
-	assert.Equal(t, 180, dusr[1].BytesTransferred)
-	assert.Equal(t, 27, dusr[1].RowsReturned)
+	assert.Equal(t, 180, dusr[1].Bytes)
+	assert.Equal(t, 27, dusr[1].Rows)
 
 	assert.Equal(t, "transaction3", dusr[2].ExternalId)
 	assert.Equal(t, []string{"GRANT"}, dusr[2].AccessedDataObjects[0].Permissions)
 	assert.Equal(t, &data_source.DataObjectReference{FullName: "schema3", Type: "schema"}, dusr[2].AccessedDataObjects[0].DataObjectReference)
-	assert.Equal(t, true, dusr[2].Status)
+	assert.Equal(t, true, dusr[2].Success)
 	assert.Equal(t, "Bob", dusr[2].User)
 	assert.Equal(t, int64(1654073200000), dusr[2].StartTime)
 	assert.Equal(t, int64(1654073200020), dusr[2].EndTime)
-	assert.Equal(t, float32(0.02), dusr[2].TotalTime)
-	assert.Equal(t, 0, dusr[2].BytesTransferred)
-	assert.Equal(t, 0, dusr[2].RowsReturned)
+	assert.Equal(t, 0, dusr[2].Bytes)
+	assert.Equal(t, 0, dusr[2].Rows)
 }

--- a/base/data_usage/importer.go
+++ b/base/data_usage/importer.go
@@ -65,7 +65,8 @@ func (d *dataUsageFileCreator) AddStatements(statements []Statement) error {
 		return nil
 	}
 
-	for _, statement := range statements {
+	for ind := range statements {
+		statement := statements[ind]
 		var err error
 
 		if d.statementCount > 0 {

--- a/base/data_usage/importer.go
+++ b/base/data_usage/importer.go
@@ -13,9 +13,10 @@ type Statement struct {
 	ExternalId          string      `json:"externalId"`
 	AccessedDataObjects []ap.Access `json:"accessedDataObjects"`
 	User                string      `json:"user"`
+	Role                string      `json:"role"`
 	Success             bool        `json:"success"`
-	Query               string      `json:"query"`
 	Status              string      `json:"status"`
+	Query               string      `json:"query"`
 	StartTime           int64       `json:"startTime"`
 	EndTime             int64       `json:"endTime"`
 	Bytes               int         `json:"bytes"`

--- a/base/data_usage/importer.go
+++ b/base/data_usage/importer.go
@@ -12,13 +12,15 @@ import (
 type Statement struct {
 	ExternalId          string      `json:"externalId"`
 	AccessedDataObjects []ap.Access `json:"accessedDataObjects"`
-	Status              bool        `json:"status"`
 	User                string      `json:"user"`
+	Success             bool        `json:"success"`
+	Query               string      `json:"query"`
+	Status              string      `json:"status"`
 	StartTime           int64       `json:"startTime"`
 	EndTime             int64       `json:"endTime"`
-	TotalTime           float32     `json:"totalTime"`
-	BytesTransferred    int         `json:"bytesTransferred"`
-	RowsReturned        int         `json:"rowsReturned"`
+	Bytes               int         `json:"bytes"`
+	Rows                int         `json:"rows"`
+	Credits             float32     `json:"credits"`
 }
 
 // DataUsageFileCreator describes the interface for easily creating the data usage import files

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -416,7 +416,6 @@ func syncDataUsage(client plugin.PluginClient, targetConfig target.BaseTargetCon
 		timeValue := time.Unix(int64(0), 0)
 		lastUsed = &timeValue
 	}
-	logger.Info(fmt.Sprintf("Only retrieve usage information after %s", lastUsed.Format(time.RFC3339)))
 
 	syncerConfig.ConfigMap.Parameters["lastUsed"] = (*lastUsed).Format(time.RFC3339)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -417,7 +417,8 @@ func syncDataUsage(client plugin.PluginClient, targetConfig target.BaseTargetCon
 		lastUsed = &timeValue
 	}
 
-	syncerConfig.ConfigMap.Parameters["lastUsed"] = (*lastUsed).Format(time.RFC3339)
+	lastUsedValue := *lastUsed
+	syncerConfig.ConfigMap.Parameters["lastUsed"] = lastUsedValue.Format(time.RFC3339)
 
 	res := dus.SyncDataUsage(&syncerConfig)
 	if res.Error != nil {

--- a/internal/data_usage/importer.go
+++ b/internal/data_usage/importer.go
@@ -113,6 +113,7 @@ func (d *dataUsageImporter) GetLastUsage() (*time.Time, error) {
 	}
 
 	finalResult := time.Unix(int64(0), 0)
+
 	if res.DataSourceInfo.LastUsed != "" {
 		finalResultRaw, err := time.Parse(time.RFC3339, res.DataSourceInfo.LastUsed)
 		if err == nil {

--- a/internal/data_usage/importer.go
+++ b/internal/data_usage/importer.go
@@ -69,7 +69,7 @@ func (d *dataUsageImporter) doImport(fileKey string) (*DataUsageImportResult, er
 	gqlQuery := fmt.Sprintf(`{ "operationName": "ImportDataUsage", "variables":{}, "query": "mutation ImportDataUsage {
         importDataUsage(input: {
           dataSource: \"%s\",
-          dataObjects: \"%s\"
+          fileKey: \"%s\"
         }) {
           statementsAdded
           statementsFailed


### PR DESCRIPTION
- https://github.com/raito-io/global/issues/54: renaming on a field in the data usage import API
- https://github.com/raito-io/global/issues/67: 'finalize' data contract of data usage info/file format for now
- https://github.com/raito-io/global/issues/79: retrieve 'last used' date for a data source and pass it to the plugin as a configuration parameter
- Use/log all the results from the import API (also edges that were created/updated and deleted)

After merging the corresponding PR in the appserver (https://github.com/raito-io/appserver/pull/146), a new version of the CLI should be released for the data usage import to work. A new version is also needed to complete the corresponding Snowflake plugin PR: https://github.com/raito-io/cli-plugin-snowflake/pull/27. 