### PR TITLE
add objects to support S3

### DIFF
--- a/base/data_source/api.go
+++ b/base/data_source/api.go
@@ -26,6 +26,10 @@ const (
 	View       = "view"
 	Column     = "column"
 	Dataset    = "dataset"
+	Bucket     = "bucket"
+	Object     = "object"
+	Folder     = "folder"
+	File       = "file"
 
 	/*
 		The list of global permissions


### PR DESCRIPTION
Not sure if we need this here, but other plugins are using these constants in the CLI repo as well, so we might as well do the same for S3. 