### PR TITLE
check consistency of extra usage metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hasura/go-graphql-client v0.9.3
 	github.com/jinzhu/copier v0.3.5
 	github.com/pterm/pterm v0.12.61
+	github.com/raito-io/golang-set v0.0.4
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -311,6 +311,8 @@ github.com/pterm/pterm v0.12.36/go.mod h1:NjiL09hFhT/vWjQHSj1athJpx6H8cjpHXNAK5b
 github.com/pterm/pterm v0.12.40/go.mod h1:ffwPLwlbXxP+rxT0GsgDTzS3y3rmpAO1NMjUkGTYf8s=
 github.com/pterm/pterm v0.12.61 h1:cZFweZ0C4zbBsusyThfgqg0KU0PTnq5xupnGN3Ytxzc=
 github.com/pterm/pterm v0.12.61/go.mod h1:07yyGZKQr8BpKKBaOZI1qKzzngqUisHdSYR4fQ9Nb4g=
+github.com/raito-io/golang-set v0.0.4 h1:7zk8r1TCE/F9JOOgseIXYx7oZJdC9/j5uivkCYjnCg0=
+github.com/raito-io/golang-set v0.0.4/go.mod h1:ktKACNnQeSpzo0Nes6jDTs74UOau8psJpAesatiEKQE=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/data_source/metadata_test.go
+++ b/internal/data_source/metadata_test.go
@@ -1,0 +1,119 @@
+package data_source
+
+import (
+	"testing"
+
+	"github.com/raito-io/cli/base/data_source"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetaData_InputEmpty(t *testing.T) {
+
+	input := data_source.MetaData{}
+
+	err := metadataConsistencyCheck(&input)
+	assert.Nil(t, err)
+}
+
+func TestMetaData_DefaultLevelEmpty(t *testing.T) {
+
+	input := data_source.MetaData{
+		UsageMetaInfo: &data_source.UsageMetaInput{
+			DefaultLevel: "",
+		},
+	}
+
+	err := metadataConsistencyCheck(&input)
+	assert.Nil(t, err)
+}
+
+func TestMetaData_DefaultLevelNotDefined(t *testing.T) {
+
+	input := data_source.MetaData{
+		UsageMetaInfo: &data_source.UsageMetaInput{
+			DefaultLevel: "",
+			Levels: []*data_source.UsageMetaInputDetail{
+				{
+					Name:            "not_test",
+					DataObjectTypes: []string{"something"},
+				},
+			},
+		},
+	}
+
+	err := metadataConsistencyCheck(&input)
+	assert.NotNil(t, err)
+
+	input = data_source.MetaData{
+		UsageMetaInfo: &data_source.UsageMetaInput{
+			DefaultLevel: "test",
+			Levels: []*data_source.UsageMetaInputDetail{
+				{
+					Name:            "not_test",
+					DataObjectTypes: []string{"something"},
+				},
+			},
+		},
+	}
+
+	err = metadataConsistencyCheck(&input)
+	assert.NotNil(t, err)
+}
+
+func TestMetaData_LevelsNotDefinedInDataObjectTypes(t *testing.T) {
+
+	input := data_source.MetaData{
+		UsageMetaInfo: &data_source.UsageMetaInput{
+			DefaultLevel: "table",
+			Levels: []*data_source.UsageMetaInputDetail{
+				{
+					Name:            "table",
+					DataObjectTypes: []string{"table"},
+				},
+			},
+		},
+	}
+
+	err := metadataConsistencyCheck(&input)
+	assert.NotNil(t, err)
+
+	input = data_source.MetaData{
+		DataObjectTypes: []*data_source.DataObjectType{
+			{
+				Name: "table",
+			},
+		},
+		UsageMetaInfo: &data_source.UsageMetaInput{
+			DefaultLevel: "table",
+			Levels: []*data_source.UsageMetaInputDetail{
+				{
+					Name:            "table",
+					DataObjectTypes: []string{"table"},
+				},
+			},
+		},
+	}
+
+	err = metadataConsistencyCheck(&input)
+	assert.Nil(t, err)
+
+	input = data_source.MetaData{
+		DataObjectTypes: []*data_source.DataObjectType{
+			{
+				Name: "table",
+			},
+		},
+		UsageMetaInfo: &data_source.UsageMetaInput{
+			DefaultLevel: "table",
+			Levels: []*data_source.UsageMetaInputDetail{
+				{
+					Name:            "table",
+					DataObjectTypes: []string{"table", "view"},
+				},
+			},
+		},
+	}
+
+	err = metadataConsistencyCheck(&input)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
Add consistency checks - before actually starting to use it in appserver - in the metadata that's sent for data usage.