### PR TITLE
Raito 1501 cli implement cronjob for continuous sync

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -46,7 +46,7 @@ func initRunCommand(rootCmd *cobra.Command) {
 	}
 
 	cmd.PersistentFlags().StringP(constants.CronFlag, "c", "", "If set, the cron expression will define when a sync should run. When not set (and no frequency is defined), the sync will run once and quit after.")
-	cmd.PersistentFlags().Bool(constants.SyncAtStartupFlag, false, "If set a sync will be run at startup independent of the cron expression.")
+	cmd.PersistentFlags().Bool(constants.SyncAtStartupFlag, false, "If set, a sync will be run at startup independent of the cron expression. Only applicable if cron expression is defined.")
 	cmd.PersistentFlags().IntP(constants.FrequencyFlag, "f", 0, "The frequency used to do the sync (in minutes). When not set (and no cron expression is defined), the default value '0' is used, which means the sync will run once and quit after.")
 	cmd.PersistentFlags().Bool(constants.SkipDataSourceSyncFlag, false, "If set, the data source meta data synchronization step to Raito will be skipped for each of the targets.")
 	cmd.PersistentFlags().Bool(constants.SkipIdentityStoreSyncFlag, false, "If set, the identity store synchronization step to Raito will be skipped for each of the targets.")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/bits"
 	"os"
 	"os/signal"
 	sync2 "sync"
 	"syscall"
 	"time"
 
+	"github.com/robfig/cron/v3"
 	"google.golang.org/grpc/codes"
 
 	"github.com/raito-io/cli/base/util/error/grpc_error"
@@ -42,7 +44,10 @@ func initRunCommand(rootCmd *cobra.Command) {
 		Long:   `Run all the configured synchronizations`,
 		Run:    executeRun,
 	}
-	cmd.PersistentFlags().IntP(constants.FrequencyFlag, "f", 0, "The frequency used to do the sync (in minutes). When not set, the default value '0' is used, which means the sync will run once and quit after.")
+
+	cmd.PersistentFlags().StringP(constants.CronFlag, "c", "", "If set, the cron expression will define when a sync should be run. When not set, the sync will run once and quit after.")
+	cmd.PersistentFlags().Bool(constants.SyncAtStartupFlag, false, "If set a sync will be run at startup independent of the cron expression.")
+	cmd.PersistentFlags().IntP(constants.FrequencyFlag, "f", 0, "(Deprecated) The frequency used to do the sync (in minutes). When not set (and no cron expression is defined), the default value '0' is used, which means the sync will run once and quit after.")
 	cmd.PersistentFlags().Bool(constants.SkipDataSourceSyncFlag, false, "If set, the data source meta data synchronization step to Raito will be skipped for each of the targets.")
 	cmd.PersistentFlags().Bool(constants.SkipIdentityStoreSyncFlag, false, "If set, the identity store synchronization step to Raito will be skipped for each of the targets.")
 	cmd.PersistentFlags().Bool(constants.SkipDataAccessSyncFlag, false, "If set, the data access information from Raito will not be synced to the data sources in the target list.")
@@ -60,6 +65,8 @@ func initRunCommand(rootCmd *cobra.Command) {
 	cmd.PersistentFlags().Bool(constants.DisableLogForwardingIdentityStoreSync, false, "If set, identity store sync logs will not be forwarded to Raito Cloud.")
 	cmd.PersistentFlags().Bool(constants.DisableLogForwardingDataUsageSync, false, "If set, data usage sync logs will not be forwarded to Raito Cloud.")
 
+	BindFlag(constants.CronFlag, cmd)
+	BindFlag(constants.SyncAtStartupFlag, cmd)
 	BindFlag(constants.FrequencyFlag, cmd)
 	BindFlag(constants.SkipDataSourceSyncFlag, cmd)
 	BindFlag(constants.SkipIdentityStoreSyncFlag, cmd)
@@ -90,8 +97,13 @@ func executeRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	freq := viper.GetInt(constants.FrequencyFlag)
-	if freq <= 0 {
+	executeSyncAtStartup, scheduler, err := createSyncScheduler(baseConfig)
+	if err != nil {
+		hclog.L().Error(err.Error())
+		os.Exit(1)
+	}
+
+	if scheduler == nil {
 		hclog.L().Info("Running synchronization just once.")
 
 		baseConfig.BaseLogger = baseConfig.BaseLogger.With("iteration", 0)
@@ -103,10 +115,8 @@ func executeRun(cmd *cobra.Command, args []string) {
 			os.Exit(0)
 		}
 	} else {
-		hclog.L().Info(fmt.Sprintf("Starting synchronization every %d minutes.", freq))
+		hclog.L().Info("Starting continuous synchronization.")
 		hclog.L().Info("Press 'ctrl+c' to stop the program.")
-
-		ticker := time.NewTicker(time.Duration(freq) * time.Minute)
 
 		ctx, cancelFn := context.WithCancel(context.Background())
 
@@ -121,7 +131,6 @@ func executeRun(cmd *cobra.Command, args []string) {
 
 		go func() {
 			defer waitGroup.Done()
-			defer ticker.Stop()
 
 			cliTriggerCtx, cliTriggerCancel := context.WithCancel(ctx)
 			cliTrigger, apUpdateTrigger := startListingToCliTriggers(cliTriggerCtx, baseConfig)
@@ -132,21 +141,33 @@ func executeRun(cmd *cobra.Command, args []string) {
 				apUpdateTrigger.Close()
 			}()
 
-			baseConfig.BaseLogger = baseConfig.BaseLogger.With("iteration", 1)
-			if runErr := executeSingleRun(baseConfig); runErr != nil {
-				baseConfig.BaseLogger.Error(fmt.Sprintf("Run failed: %s", runErr.Error()))
+			it := 1
+			executionStartTime := time.Now()
+
+			if executeSyncAtStartup {
+				baseConfig.BaseLogger = baseConfig.BaseLogger.With("iteration", it)
+				if runErr := executeSingleRun(baseConfig); runErr != nil {
+					baseConfig.BaseLogger.Error(fmt.Sprintf("Run failed: %s", runErr.Error()))
+				}
+
+				it++
 			}
 
-			it := 2
+			timer := cronTimer(baseConfig.BaseLogger, nil, scheduler, &executionStartTime)
+			defer timer.Stop()
+
 			for {
 				select {
-				case <-ticker.C:
+				case <-timer.C:
+					executionStartTime = time.Now()
 					cliTrigger.Reset()
 
 					baseConfig.BaseLogger = baseConfig.BaseLogger.With("iteration", it)
 					if runErr := executeSingleRun(baseConfig); runErr != nil {
 						baseConfig.BaseLogger.Error(fmt.Sprintf("Run failed: %s", runErr.Error()))
 					}
+
+					cronTimer(baseConfig.BaseLogger, timer, scheduler, &executionStartTime)
 
 					it++
 				case <-apUpdateTrigger.TriggerChannel():
@@ -201,6 +222,67 @@ func executeRun(cmd *cobra.Command, args []string) {
 			hclog.L().Debug("Exit with code: %d", returnSignal)
 			syscall.Exit(returnSignal)
 		}
+	}
+}
+
+func createSyncScheduler(baseConfig *target.BaseConfig) (bool, cron.Schedule, error) {
+	executeSyncAtStartup := viper.GetBool(constants.SyncAtStartupFlag)
+	var scheduler cron.Schedule
+
+	cronExpression := viper.GetString(constants.CronFlag)
+	if cronExpression == "" {
+		freq := viper.GetInt(constants.FrequencyFlag)
+		if freq > 0 {
+			baseConfig.BaseLogger.Warn("The 'frequency' flag is deprecated. Please use the 'cron' flag instead.")
+
+			if freq < 60 {
+				return false, nil, fmt.Errorf("the 'frequency' flag must be at least 60 seconds. The value is: %d", freq)
+			}
+
+			executeSyncAtStartup = true
+			scheduler = cron.Every(time.Minute * time.Duration(freq))
+		}
+	} else {
+		var cronParserErr error
+		scheduler, cronParserErr = cron.ParseStandard(cronExpression)
+
+		specSchedule, ok := scheduler.(*cron.SpecSchedule)
+		if ok {
+			if moreThanOneExecutionWithinAnHour(specSchedule) {
+				return false, nil, errors.New("cron expression will trigger sync multiple times within an hour")
+			}
+		}
+
+		if cronParserErr != nil {
+			return false, nil, cronParserErr
+		}
+	}
+
+	return executeSyncAtStartup, scheduler, nil
+}
+
+func moreThanOneExecutionWithinAnHour(cronSchedule *cron.SpecSchedule) bool {
+	prefix := uint64(1) << 63
+
+	if bits.OnesCount64(cronSchedule.Second&^prefix) > 1 || bits.OnesCount64(cronSchedule.Minute&^prefix) > 1 {
+		return true
+	}
+
+	return false
+}
+
+func cronTimer(logger hclog.Logger, timer *time.Timer, scheduler cron.Schedule, previousStartTime *time.Time) *time.Timer {
+	next := scheduler.Next(*previousStartTime)
+
+	logger.Info(fmt.Sprintf("Next execution at %s", next.Format(time.RFC822)))
+
+	waitTime := time.Until(next)
+
+	if timer == nil {
+		return time.NewTimer(waitTime)
+	} else {
+		timer.Reset(waitTime)
+		return timer
 	}
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -45,7 +45,7 @@ func initRunCommand(rootCmd *cobra.Command) {
 		Run:    executeRun,
 	}
 
-	cmd.PersistentFlags().StringP(constants.CronFlag, "c", "", "If set, the cron expression will define when a sync should run. When not set (and no frequency is defined), the sync will run once and quit after.")
+	cmd.PersistentFlags().StringP(constants.CronFlag, "c", "", "If set, the cron expression will define when a sync should run. When not set (and no frequency is defined), the sync will run once and quit after. (e.g. '0 0/2 * * *' initiates a sync evey 2 hours)")
 	cmd.PersistentFlags().Bool(constants.SyncAtStartupFlag, false, "If set, a sync will be run at startup independent of the cron expression. Only applicable if cron expression is defined.")
 	cmd.PersistentFlags().IntP(constants.FrequencyFlag, "f", 0, "The frequency used to do the sync (in minutes). When not set (and no cron expression is defined), the default value '0' is used, which means the sync will run once and quit after.")
 	cmd.PersistentFlags().Bool(constants.SkipDataSourceSyncFlag, false, "If set, the data source meta data synchronization step to Raito will be skipped for each of the targets.")

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_moreThanOneExecutionWithinAnHour(t *testing.T) {
+	type args struct {
+		cronExpression string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "At every minute",
+			args: args{
+				cronExpression: "* * * * *",
+			},
+			want: true,
+		},
+		{
+			name: "At minute 0",
+			args: args{
+				cronExpression: "0 * * * *",
+			},
+			want: false,
+		},
+		{
+			name: "At every minute past hour 1 on day-of-month 2 in April",
+			args: args{
+				cronExpression: "* 1 2 4 *",
+			},
+			want: true,
+		},
+		{
+			name: "At every 15th minute from 0 through 59",
+			args: args{
+				cronExpression: "0/15 * * * *",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schedule, err := cron.ParseStandard(tt.args.cronExpression)
+			require.NoError(t, err)
+
+			specSchedule := schedule.(*cron.SpecSchedule)
+
+			assert.Equalf(t, tt.want, moreThanOneExecutionWithinAnHour(specSchedule), "moreThanOneExecutionWithinAnHour(%v)", tt.args.cronExpression)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rs/zerolog v1.29.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/pterm/pterm v0.12.61
 	github.com/raito-io/golang-set v0.0.4
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.3
@@ -70,7 +71,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rs/zerolog v1.29.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -316,6 +316,8 @@ github.com/raito-io/golang-set v0.0.4/go.mod h1:ktKACNnQeSpzo0Nes6jDTs74UOau8psJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -11,6 +11,8 @@ var KnownFlags = map[string]struct{}{
 	ApiSecretFlag:             {},
 	ConfigFileFlag:            {},
 	FrequencyFlag:             {},
+	CronFlag:                  {},
+	SyncAtStartupFlag:         {},
 	SkipIdentityStoreSyncFlag: {},
 	SkipDataSourceSyncFlag:    {},
 	SkipDataAccessSyncFlag:    {},
@@ -39,6 +41,8 @@ const (
 	ApiSecretFlag                         = "api-secret"
 	ConfigFileFlag                        = "config-file"
 	FrequencyFlag                         = "frequency"
+	CronFlag                              = "cron"
+	SyncAtStartupFlag                     = "sync-at-startup"
 	SkipDataSourceSyncFlag                = "skip-data-source-sync"
 	SkipDataAccessSyncFlag                = "skip-data-access-sync"
 	SkipIdentityStoreSyncFlag             = "skip-identity-store-sync"


### PR DESCRIPTION
Implement cron schedule for continuous CLI sync.

**New flags**
* `--cron` or `-c` : A cron expression indicating when a sync should run. If no cron expression is defined, a single run will be executed.
* `--sync-at-startup` : It cron expression is defined, run sync at start up of CLI (independent of cron expression).

**Deprecated flags**
* `--frequency` or `-f`

**New behaviour**
Within a continuous sync no more than 1 sync can be scheduled by using the `--cron` or `--frequency` flag.